### PR TITLE
chore(version): add .gitignore for version package src directory

### DIFF
--- a/packages/version/src/.gitignore
+++ b/packages/version/src/.gitignore
@@ -1,0 +1,3 @@
+genaiscript.d.ts
+tsconfig.json
+jsconfig.json


### PR DESCRIPTION
chore(version): add .gitignore for version package src directory

Context
- This repository is a submodule of anoblet/.copilot, which is itself a submodule of anoblet/astronautical-apogee
- We found an untracked .gitignore under packages/version/src that should ignore build artifacts and intermediate files for the GenAIScript version package

Changes
- Add packages/version/src/.gitignore

Notes
- Created from branch chore/version-src-gitignore-2025-08-12
- Please review; no merge will be performed by the agent per user instruction